### PR TITLE
Fix startGame: await API, Prisma shim

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+README.md text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package.json.backup
+prisma/dev.db

--- a/app/api/games/route.ts
+++ b/app/api/games/route.ts
@@ -1,0 +1,10 @@
+import prisma from "@/lib/prismaSafe";
+
+export async function POST(req: Request) {
+  const { pars } = await req.json();
+  if (!pars || !Array.isArray(pars)) {
+    return new Response("Bad request", { status: 400 });
+  }
+  const game = await prisma.game.create({ data: { pars } });
+  return Response.json({ id: game.id });
+}

--- a/app/game/[id]/page.tsx
+++ b/app/game/[id]/page.tsx
@@ -1,0 +1,3 @@
+export default function Game({ params }: { params: { id: string } }) {
+  return <div>Game {params.id}</div>;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,5 @@
+import StartButton from "../components/StartButton";
+
+export default function Home() {
+  return <StartButton selectedPars={[3,4,5]} />;
+}

--- a/components/StartButton.tsx
+++ b/components/StartButton.tsx
@@ -1,0 +1,31 @@
+import { useRouter } from "next/router";
+import { useState } from "react";
+
+export default function StartButton({ selectedPars }: { selectedPars: number[] }) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  async function startGame() {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/games", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ pars: selectedPars })
+      });
+      if (!res.ok) throw new Error("API error");
+      const { id } = await res.json();
+      router.push(`/game/${id}`);
+    } catch (err) {
+      console.error(err);
+      alert("Could not create game. Try again.");
+      setLoading(false);
+    }
+  }
+
+  return (
+    <button onClick={startGame} disabled={loading}>
+      {loading ? "Creating game…" : "Start Game"}
+    </button>
+  );
+}

--- a/lib/prismaSafe.ts
+++ b/lib/prismaSafe.ts
@@ -1,0 +1,6 @@
+import { PrismaClient } from "@prisma/client";
+const prisma =
+  process.env.NEXT_PUBLIC_V0_PREVIEW === "true"
+    ? ({ game: { create: async ({ data }) => ({ id: "demo123", ...data }) } } as any)
+    : new PrismaClient();
+export default prisma;

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "v0avatar",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "postinstall": "prisma generate"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "@prisma/client": "latest",
+    "zustand": "latest"
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,14 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:dev.db"
+}
+
+model Game {
+  id        String   @id @default(cuid())
+  pars      Int[]
+  createdAt DateTime @default(now())
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "esnext",
+    "jsx": "preserve",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/types/Game.ts
+++ b/types/Game.ts
@@ -1,0 +1,1 @@
+export type Game = { id: string; pars: number[]; createdAt?: Date };


### PR DESCRIPTION
## Summary
- add Next.js boilerplate with TypeScript config
- implement API route using a preview-safe Prisma shim
- add StartButton component that awaits the API call
- stub Game type and Prisma schema
- configure package.json with required deps and scripts
- set up gitignore and gitattributes

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a35c1d320832b81b2804ad45bedec